### PR TITLE
compact description in plain embeds; compact code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ cached = { version = "0.55.1", features = ["async"] }
 chrono = "0.4.40"
 # bytes = "1.4.0"
 dotenvy = "0.15"
+fancy-regex = "0.14.0"
 http = "0.2"
 isbot = "0.1"
 itertools = "0.11.0"


### PR DESCRIPTION
## Why

Since Telegram does not know Mastodon-like API like Discord, the appearance of the embeds does not look fine in some cases. The Telegram Android shows 6 lines of description, while the Windows client only shows 3 lines. That's too short for caption of artworks. Even worse, if the author has added styles or links to the caption, a bunch of plaintext HTML stuff will be displayed. 

This PR does two modifications to the description of plain embeds:

- Put our AI markup in the 1st line of its content.
- Extract all visible strings (innerText) from its HTML. In other words, remove HTML stuff from its content.

A new dependency "fancy-regex" has been introduced since I need some functionality that does not belong to the real RegExp. That is, for example, backreference:

> ... The regex syntax supported by this crate is similar
to other regex engines, but it lacks several features that are not known how to
implement efficiently. This includes, but is not limited to, look-around and
backreferences. ...
> 
> _from: https://github.com/rust-lang/regex/blob/1a069b9232c607b34c4937122361aa075ef573fa/README.md?plain=1#L4C28-L7C16_

.

## Comparison

### pixiv-131487018

Its description is:

> Boothにて投稿＋αのまとめたイラスト集などを販売してます。<br><a href="https://b-ai-cat.booth.pm/" target="_blank" rel="noopener">https://b-ai-cat.booth.pm/</a><br>ぜひ支援よろしくお願いします。<br>ブックマーク、いいね、ぜひよろしくお願いします<br>タグも作品に合うと思ったら追加してくれたらうれしいです<br>Xもやってます。<br><a href="/jump.php?https%3A%2F%2Fx.com%2Fb_neko0505%2F" target="_blank" rel="noopener">https://x.com/b_neko0505/</a>

```HTML
Boothにて投稿＋αのまとめたイラスト集などを販売してます。<br><a href="https://b-ai-cat.booth.pm/" target="_blank" rel="noopener">https://b-ai-cat.booth.pm/</a><br>ぜひ支援よろしくお願いします。<br>ブックマーク、いいね、ぜひよろしくお願いします<br>タグも作品に合うと思ったら追加してくれたらうれしいです<br>Xもやってます。<br><a href="/jump.php?https%3A%2F%2Fx.com%2Fb_neko0505%2F" target="_blank" rel="noopener">https://x.com/b_neko0505/</a>

```

Before:

```
AI Generated

Boothにて投稿＋αのまとめたイラスト集などを販売してます。<br /><a href="https://b-ai-cat.booth.pm/" target="_blank">https://b-ai-cat.booth.pm/</a><br />ぜひ支援よろしくお願いします。<br />ブックマーク、いいね、ぜひよろしくお願いします<br />タグも作品に合うと思ったら追加してくれたらうれしいです<br />Xもやってます。<br /><a href="/jump.php?https%3A%2F%2Fx.com%2Fb_neko0505%2F" target="_blank">https://x.com/b_neko0505/</a>
#Uma Musume Pretty Derby, #Silence Suzuka (Uma Musume), #horse girl, #Silence Suzuka

```

After:

```
[AI Generated] Boothにて投稿＋αのまとめたイラスト集などを販売してます。
https://b-ai-cat.booth.pm/
ぜひ支援よろしくお願いします。
ブックマーク、いいね、ぜひよろしくお願いします
タグも作品に合うと思ったら追加してくれたらうれしいです
Xもやってます。
https://x.com/b_neko0505/
#Uma Musume Pretty Derby, #Silence Suzuka (Uma Musume), #horse girl, #Silence Suzuka

```

### pixiv-131485608

Its description is:

> <strong><a href="/en/artworks/130915154">illust/130915154</a></strong>のアスナ＆宮水三葉バージョン。

```HTML
<strong><a href="/en/artworks/130915154">illust/130915154</a></strong>のアスナ＆宮水三葉バージョン。

```

Before:

```
AI Generated

<strong><a href="https://www.pixiv.net/en/artworks/130915154">illust/130915154</a></strong>のアスナ＆宮水三葉バージョン。
#NovelAI, #competition swimsuits, #high-leg leotard, #Asuna (SAO), #Mitsuha Miyamizu, #hair down, #sexy thighs, #groin, #インフィニティプール, #yuri

```

After:

```
[AI Generated] illust/130915154 のアスナ＆宮水三葉バージョン。
#NovelAI, #competition swimsuits, #high-leg leotard, #Asuna (SAO), #Mitsuha Miyamizu, #hair down, #sexy thighs, #groin, #インフィニティプール, #yuri

```

.