### PR TITLE
fully handle API requests with image indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ There are some APIs for developers or internal usage. It's recommended to read t
 | `/health` | Health check |
 | `/e/?n=:author_name&i=:author_id` | oEmbed-like API |
 | `/i/:path` | Proxy API |
-| `/api/info?id=:id&language=:language` | Basic info (e.g., direct image links and tags) in JSON |
+| `/api/info?id=:id&language=:language&index=:index` | Basic info (e.g., direct image links and tags) in JSON |
 | `/api/v1/statuses/:status_id` | Mastodon-like API |

--- a/src/api/activity.rs
+++ b/src/api/activity.rs
@@ -210,6 +210,7 @@ pub async fn activity_handler(
     let listing = ArtworkListing::get_listing(
         activity_id.language,
         activity_id.id.to_string(),
+        activity_id.index as usize,
         &host,
         &state.client,
     )

--- a/src/api/info.rs
+++ b/src/api/info.rs
@@ -13,6 +13,7 @@ use crate::{helper::PhixivError, pixiv::ArtworkListing, state::PhixivState};
 pub struct ArtworkInfoPath {
     pub language: Option<String>,
     pub id: String,
+    pub index: Option<usize>,
 }
 
 pub(super) async fn artwork_info_handler(
@@ -26,6 +27,7 @@ pub(super) async fn artwork_info_handler(
         ArtworkListing::get_listing(
             path.language.unwrap_or_else(|| "jp".to_string()),
             path.id,
+            path.index.unwrap_or_else(|| 0),
             &host,
             &state.client,
         )

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -29,6 +29,7 @@ async fn artwork_response(
     let listing = ArtworkListing::get_listing(
         path.language.unwrap_or_else(|| "jp".to_string()),
         path.id,
+        path.image_index.unwrap_or_else(|| 0),
         &host,
         &state.client,
     )

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -97,13 +97,17 @@ fn filter_bots(user_agent: UserAgent, raw_path: &RawArtworkPath) -> Option<Respo
 
         if !bots.is_bot(user_agent.as_str()) {
             let redirect_uri = format!(
-                "https://www.pixiv.net{}/artworks/{}",
+                "https://www.pixiv.net{}/artworks/{}{}",
                 raw_path
                     .language
                     .as_ref()
                     .map(|l| format!("/{l}"))
                     .unwrap_or_else(|| String::from("")),
-                raw_path.id
+                raw_path.id,
+                raw_path.image_index
+                    .as_ref()
+                    .map(|i| format!("#{i}"))
+                    .unwrap_or_else(|| String::from("")),
             );
             return Some(Redirect::temporary(&redirect_uri).into_response());
         }

--- a/src/pixiv/mod.rs
+++ b/src/pixiv/mod.rs
@@ -246,10 +246,15 @@ impl ArtworkListing {
     pub async fn get_listing(
         language: String,
         illust_id: String,
+        image_index: usize,
         host: &str,
         client: &Client,
     ) -> anyhow::Result<Self> {
-        cached_get_listing(language, illust_id, host, client).await
+        let mut listing = cached_get_listing(language, illust_id, host, client).await?;
+        if image_index != 0 {
+            listing.url = format!("{}#{}", listing.url, image_index)
+        }
+        Ok(listing)
     }
 
     pub fn to_template(self, image_index: Option<usize>, host: String) -> anyhow::Result<String> {


### PR DESCRIPTION
Hi! Since there are anchors on pixiv illustration pages, we can make https://www.phixiv.net/en/artworks/132505294/3 point to https://www.pixiv.net/en/artworks/132505294#3 .

Please review.