### PR TITLE
Configure client's connection tracing via env; fix dotenv loading

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -8,4 +8,5 @@ PROVIDER_URL=https://github.com/thelaao/phixiv
 PXIMG_BASE=https://i.pximg.net/
 UGOIRA_ENABLED=false
 PIXIV_COOKIE=
-USER_AGENT=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36
+USER_AGENT='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36'
+TRACE_CLIENT_NETWORK=false

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use tracing_subscriber::{
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    dotenvy::dotenv().ok();
+    dotenvy::dotenv()?;
 
     let addr: SocketAddr = format!(
         "[::]:{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use std::{env, net::SocketAddr, sync::Arc};
 
 use api::api_router;
 use axum::{response::IntoResponse, routing::get, Json, Router};
+use dotenvy::Error as DotenvyError;
 use oembed::oembed_handler;
 use proxy::proxy_router;
 use serde_json::json;
@@ -26,7 +27,11 @@ use tracing_subscriber::{
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    dotenvy::dotenv()?;
+    match dotenvy::dotenv() {
+        Ok(_) => (),
+        Err(DotenvyError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {},
+        Err(e) => return Err(e.into()),
+    }
 
     let addr: SocketAddr = format!(
         "[::]:{}",

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,5 @@
 use reqwest::Client;
+use std::env;
 
 #[derive(Clone)]
 pub struct PhixivState {
@@ -7,7 +8,13 @@ pub struct PhixivState {
 
 impl PhixivState {
     pub async fn login() -> anyhow::Result<Self> {
-        let client = Client::new();
+        let verbose = env::var("TRACE_CLIENT_NETWORK")
+            .unwrap_or_else(|_| String::from("false"))
+            == "true";
+
+        let client = Client::builder()
+            .connection_verbose(verbose)
+            .build()?;
 
         Ok(Self { client })
     }


### PR DESCRIPTION
This will produce logs like:

```
TRACE reqwest::connect::verbose: 00000000 write: b"GET /ajax/illust/...
TRACE reqwest::connect::verbose: 00000000 read: b"HTTP/1.1 200 OK\r\nDate: Jia, 1 Tan 2026 00:00:00 GMT\r\nContent-Type: application/json; ...

```

.